### PR TITLE
Fix PDF links

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@ function renderFiles(client) {
               `<p class="font-medium text-white">${file.fileName}</p>`+
               `<p class="text-sm text-gray-400">Fecha: ${file.uploadDate}</p>`+
               `</div>`+
-              `<a href="${file.fileURL}" target="_blank" class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-md">Descargar</a>`+
+              `<a href="${file.fileURL}" download class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-md">Descargar</a>`+
               `</li>`;
     });
     html += '</ul>';


### PR DESCRIPTION
## Summary
- download client PDFs directly instead of opening a blank tab

## Testing
- `tidy -q index.html`

------
https://chatgpt.com/codex/tasks/task_e_688a1eb54b048326b0b4a73c4234155d