### PR TITLE
Fix download link and add CSV export

### DIFF
--- a/data/sample_clients.csv
+++ b/data/sample_clients.csv
@@ -1,0 +1,3 @@
+access_code,client_name
+ABC123,Juan Pérez
+XYZ789,Ana López

--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@ function renderFiles(client) {
               `<p class="font-medium text-white">${file.fileName}</p>`+
               `<p class="text-sm text-gray-400">Fecha: ${file.uploadDate}</p>`+
               `</div>`+
-              `<a href="${file.fileURL}" download class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-md">Descargar</a>`+
+              `<a href="${file.fileURL}" download target="_blank" rel="noopener" class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-md">Descargar</a>`+
               `</li>`;
     });
     html += '</ul>';

--- a/update_sample_csv.py
+++ b/update_sample_csv.py
@@ -1,0 +1,21 @@
+import json
+import csv
+from pathlib import Path
+
+def main():
+    data_file = Path('data/clients.json')
+    out_file = Path('data/sample_clients.csv')
+    if not data_file.exists():
+        raise SystemExit(f"Missing {data_file}")
+    with data_file.open() as f:
+        clients = json.load(f)
+    # Write CSV with header: access_code,client_name
+    with out_file.open('w', newline='') as f:
+        writer = csv.writer(f)
+        writer.writerow(['access_code', 'client_name'])
+        for code, info in clients.items():
+            writer.writerow([code, info.get('clientName', '')])
+    print(f"Written {len(clients)} clients to {out_file}")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- fix blank page on download by forcing downloads to open in a new tab
- add script to generate a CSV with all current clients
- include generated sample CSV

## Testing
- `python3 update_sample_csv.py`

------
https://chatgpt.com/codex/tasks/task_e_688a2b2c3bc883269320e4d24a236701